### PR TITLE
Blog feature

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -70,6 +70,19 @@ module.exports = (config) => {
         passport.authenticate('bearer', (err, user, info) => {
             if (err) return next(err);
 
+            // Get bearer token from Authorization Header and check if bearer token is null or if
+            // it only contains "Bearer"
+            const bearerToken = req.header('authorization');
+            if (!bearerToken || bearerToken.length < 7) {
+                return res.status(401).json({
+                    auth: false,
+                    message: 'Token not found in Authorization headers',
+                    error: true,
+                    statusCode: 401,
+                    data: null,
+                });
+            }
+
             if (!user) {
                 const errorDesc = info.split(', ')[2];
                 const errorDescIndex = errorDesc.indexOf('"') + 1; // Remove opening apostrophe

--- a/server/routes/blog/post.js
+++ b/server/routes/blog/post.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 const express = require('express');
 const { ValidationError } = require('sequelize');
 const ApiResponse = require('../../lib/ApiResponse');
@@ -15,6 +16,52 @@ module.exports = (params) => {
             const allPosts = await posts.getAll();
 
             return response.json(api.success(allPosts));
+        } catch (err) {
+            return next(err);
+        }
+    });
+
+    router.get('/monthsAndYears', async (request, response, next) => {
+        try {
+            const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+            const monthWithNum = {};
+
+            for (let i = 0; i < months.length; i++) {
+                let key = 0;
+                if (i < 9) {
+                    key = `0${i + 1}`;
+                } else {
+                    key = `${i + 1}`;
+                }
+                monthWithNum[months[i]] = key;
+            }
+
+            const startYear = 2011;
+            const endYear = 2022;
+            const monthWithYear = [];
+            const allPosts = await posts.getAll();
+
+            for (const [key, value] of Object.entries(monthWithNum)) {
+                for (let j = startYear; j < endYear; j++) {
+                    for (let k = 0; k < allPosts.length; k++) {
+                        const postDate = allPosts[k].date;
+                        const postYear = postDate.split('-')[0];
+                        const postMonth = postDate.split('-')[1];
+
+                        // Check if there's post for a given year and month (based on key)
+                        if (j.toString() === postYear && value === postMonth) {
+                            const obj = {
+                                month: postMonth,
+                                year: postYear,
+                                text: `${key} ${postYear}`,
+                            };
+                            monthWithYear.push(obj);
+                        }
+                    }
+                }
+            }
+
+            return response.json(api.success(monthWithYear));
         } catch (err) {
             return next(err);
         }

--- a/server/routes/blog/post.js
+++ b/server/routes/blog/post.js
@@ -158,6 +158,26 @@ module.exports = (params) => {
         }
     });
 
+    router.get('/users/:userId/latest', async (request, response, next) => {
+        try {
+            const checkIfIdIsInt = helpers.checkIfValidPositiveInteger(request.params.userId);
+            if (checkIfIdIsInt.error === true) {
+                return response.status(500).json(api.error(checkIfIdIsInt.message));
+            }
+
+            const user = await users.getById(request.params.userId);
+            if (!user) {
+                return response.status(404).json(api.error(helpers.addErrorMessage('userId'), 404));
+            }
+
+            const allPosts = await posts.getAllLatestByUser(request.params.userId);
+
+            return response.json(api.success(allPosts, 'Posts by user (latest 5)'));
+        } catch (err) {
+            return next(err);
+        }
+    });
+
     router.get('/:id', async (request, response, next) => {
         try {
             const checkIfIdIsInt = helpers.checkIfValidPositiveInteger(request.params.id);

--- a/server/routes/blog/post.js
+++ b/server/routes/blog/post.js
@@ -50,12 +50,22 @@ module.exports = (params) => {
 
                         // Check if there's post for a given year and month (based on key)
                         if (j.toString() === postYear && value === postMonth) {
-                            const obj = {
+                            const data = {
                                 month: postMonth,
                                 year: postYear,
                                 text: `${key} ${postYear}`,
+                                count: 1,
                             };
-                            monthWithYear.push(obj);
+
+                            const isInArray = monthWithYear.filter((obj) => obj.text === data.text).length > 0;
+
+                            if (!isInArray) {
+                                monthWithYear.push(data);
+                            } else {
+                                for (let l = 0; l < monthWithYear.length; l++) {
+                                    if (monthWithYear[l].text === data.text) monthWithYear[l].count += 1;
+                                }
+                            }
                         }
                     }
                 }

--- a/server/routes/blog/post.js
+++ b/server/routes/blog/post.js
@@ -21,6 +21,36 @@ module.exports = (params) => {
         }
     });
 
+    router.get('/year/:year/month/:month', async (request, response, next) => {
+        try {
+            const allPosts = await posts.getAllByYearMonth(request.params.year, request.params.month);
+
+            return response.json(api.success(allPosts));
+        } catch (err) {
+            return next(err);
+        }
+    });
+
+    router.get('/year/:year', async (request, response, next) => {
+        try {
+            const allPosts = await posts.getAllByYear(request.params.year);
+
+            return response.json(api.success(allPosts));
+        } catch (err) {
+            return next(err);
+        }
+    });
+
+    router.get('/month/:month', async (request, response, next) => {
+        try {
+            const allPosts = await posts.getAllByMonth(request.params.month);
+
+            return response.json(api.success(allPosts));
+        } catch (err) {
+            return next(err);
+        }
+    });
+
     router.get('/monthsAndYears', async (request, response, next) => {
         try {
             const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
@@ -56,6 +86,17 @@ module.exports = (params) => {
                                 text: `${key} ${postYear}`,
                                 count: 1,
                             };
+
+                            const isYearInArray = monthWithYear.filter((obj) => obj.text === postYear).length > 0;
+
+                            if (!isYearInArray) {
+                                const obj = { text: postYear, count: 1 };
+                                monthWithYear.push(obj);
+                            } else {
+                                for (let l = 0; l < monthWithYear.length; l++) {
+                                    if (monthWithYear[l].text === postYear) monthWithYear[l].count += 1;
+                                }
+                            }
 
                             const isInArray = monthWithYear.filter((obj) => obj.text === data.text).length > 0;
 

--- a/server/routes/blog/post.js
+++ b/server/routes/blog/post.js
@@ -41,8 +41,8 @@ module.exports = (params) => {
             const monthWithYear = [];
             const allPosts = await posts.getAll();
 
-            for (const [key, value] of Object.entries(monthWithNum)) {
-                for (let j = startYear; j < endYear; j++) {
+            for (let j = endYear; j > startYear; j--) {
+                for (const [key, value] of Object.entries(monthWithNum)) {
                     for (let k = 0; k < allPosts.length; k++) {
                         const postDate = allPosts[k].date;
                         const postYear = postDate.split('-')[0];

--- a/server/services/PostService.js
+++ b/server/services/PostService.js
@@ -127,6 +127,27 @@ class PostService {
         return posts;
     }
 
+    async getAllLatestByUser(userId) {
+        const posts = await db.Post.findAll({
+            limit: 5,
+            where: { userId },
+            include: [
+                {
+                    model: await db.Category,
+                    as: 'category',
+                },
+                {
+                    model: await db.User,
+                    as: 'user',
+                    attributes: { exclude: hideAttributes },
+                },
+            ],
+            order: [['date', 'DESC']],
+        });
+
+        return posts;
+    }
+
     async getById(id) {
         const post = await db.Post.findByPk(id, {
             include: [

--- a/server/services/PostService.js
+++ b/server/services/PostService.js
@@ -21,7 +21,7 @@ class PostService {
                     attributes: { exclude: hideAttributes },
                 },
             ],
-            order: [['createdAt', 'ASC']],
+            order: [['date', 'DESC']],
         });
 
         return posts;
@@ -41,7 +41,7 @@ class PostService {
                     attributes: { exclude: hideAttributes },
                 },
             ],
-            order: [['createdAt', 'ASC']],
+            order: [['date', 'DESC']],
         });
 
         return posts;
@@ -61,7 +61,7 @@ class PostService {
                     attributes: { exclude: hideAttributes },
                 },
             ],
-            order: [['createdAt', 'ASC']],
+            order: [['date', 'DESC']],
         });
 
         return posts;
@@ -81,7 +81,7 @@ class PostService {
                     attributes: { exclude: hideAttributes },
                 },
             ],
-            order: [['createdAt', 'ASC']],
+            order: [['date', 'DESC']],
         });
 
         return posts;
@@ -101,7 +101,7 @@ class PostService {
                     attributes: { exclude: hideAttributes },
                 },
             ],
-            order: [['createdAt', 'ASC']],
+            order: [['date', 'DESC']],
         });
 
         return posts;
@@ -121,7 +121,7 @@ class PostService {
                     attributes: { exclude: hideAttributes },
                 },
             ],
-            order: [['createdAt', 'ASC']],
+            order: [['date', 'DESC']],
         });
 
         return posts;

--- a/server/services/PostService.js
+++ b/server/services/PostService.js
@@ -1,3 +1,4 @@
+const { Op } = require('sequelize');
 const db = require('../models');
 
 const hideAttributes = ['password'];
@@ -9,6 +10,66 @@ class PostService {
 
     async getAll() {
         const posts = await db.Post.findAll({
+            include: [
+                {
+                    model: await db.Category,
+                    as: 'category',
+                },
+                {
+                    model: await db.User,
+                    as: 'user',
+                    attributes: { exclude: hideAttributes },
+                },
+            ],
+            order: [['createdAt', 'ASC']],
+        });
+
+        return posts;
+    }
+
+    async getAllByYear(year) {
+        const posts = await db.Post.findAll({
+            where: { date: { [Op.like]: `${year}-%` } },
+            include: [
+                {
+                    model: await db.Category,
+                    as: 'category',
+                },
+                {
+                    model: await db.User,
+                    as: 'user',
+                    attributes: { exclude: hideAttributes },
+                },
+            ],
+            order: [['createdAt', 'ASC']],
+        });
+
+        return posts;
+    }
+
+    async getAllByMonth(month) {
+        const posts = await db.Post.findAll({
+            where: { date: { [Op.like]: `%-${month}-%` } },
+            include: [
+                {
+                    model: await db.Category,
+                    as: 'category',
+                },
+                {
+                    model: await db.User,
+                    as: 'user',
+                    attributes: { exclude: hideAttributes },
+                },
+            ],
+            order: [['createdAt', 'ASC']],
+        });
+
+        return posts;
+    }
+
+    async getAllByYearMonth(year, month) {
+        const posts = await db.Post.findAll({
+            where: { date: { [Op.like]: `${year}-${month}-%` } },
             include: [
                 {
                     model: await db.Category,


### PR DESCRIPTION
- Added API routes for generating data for the Sidebar component in the frontend (posts by year, posts by month, posts by month-year, latest 5 posts by user id). Also added a helper route that generates a month-year text of posts that fall within that month and year (eg. if there is a `Post` record whose month and year is 2022-01, there will be a text for January 2022 along with the number of posts found for this particular combination in the frontend, but if for example a month-and year of 2019-01 has no posts, this will not show up in the frontend)
- Added error response if bearer token is not found in Authorization headers
- Modified all functions to order posts by `date` in descending order instead of `createdAt` field